### PR TITLE
Feature/handle OR

### DIFF
--- a/src/genaisrc/paper.genai.mts
+++ b/src/genaisrc/paper.genai.mts
@@ -179,7 +179,7 @@ for (const files of prompts) {
         })
         res.push({
             prompt: files.name,
-            rules: rules.filter((r) => !r.inverse).length,
+            rules: rules.filter((r) => !r.inversed).length,
             ["rules grounded"]: ruleEvals.filter((g) => g.grounded === "ok")
                 .length,
             tests: testEvals.length,

--- a/src/genaisrc/src/parsers.mts
+++ b/src/genaisrc/src/parsers.mts
@@ -9,6 +9,7 @@ import type {
     PromptPexTest,
     PromptPexTestEval,
     PromptPexTestResult,
+    PromptPexRule,
 } from "./types.mts"
 const dbg = host.logger("promptpex:parsers")
 
@@ -176,13 +177,11 @@ export function parseAllRules(
     files: PromptPexContext,
     options?: PromptPexOptions
 ) {
-    const rules = parseRules(files.rules.content, options)
-    const inverseRules = parseRules(files.inverseRules.content, options)
-    const allRules = [
-        ...rules.map((rule) => ({ rule, inverse: false })),
-        ...inverseRules.map((rule) => ({ rule, inverse: true })),
-    ]
-    return allRules
+    const parsed = JSON.parse(files.rules.content)
+    if (!Array.isArray(parsed)) {
+        throw new Error("Rules must be a JSON array.")
+    }
+    return parsed as PromptPexRule[]
 }
 
 export function parseOKERR(text: string): PromptPexEvalResultType | undefined {

--- a/src/genaisrc/src/parsers.mts
+++ b/src/genaisrc/src/parsers.mts
@@ -118,8 +118,6 @@ export function parseTestResults(
     const res = (parsers.JSON5(files.testOutputs.content) ||
         []) as PromptPexTestResult[]
     res.forEach((r) => {
-        r.inverse =
-            r.ruleid !== null && parseInt(r.ruleid as any) > rules.length
         r.metrics = r.metrics || {}
     })
     for (const r of res.filter((r) => !r.error && !r.model)) {
@@ -129,7 +127,6 @@ export function parseTestResults(
         if (diagnostics)
             throw new Error(`missing 'model' for test result ${r.id}`)
     }
-    for (const r of res) if (isNaN(r.ruleid)) r.ruleid = null
     return res
 }
 

--- a/src/genaisrc/src/reports.mts
+++ b/src/genaisrc/src/reports.mts
@@ -317,13 +317,13 @@ export async function generateJSONReport(files: PromptPexContext) {
     }
 
     const tests = [...rulesTests, ...baseLineTests].map((test) => {
-        const rule = resolveRule(allRules, test)
+        const rule = resolveRule(allRules)
         if (!rule && !test.baseline)
             errors.push(
-                `test '${test.ruleid}' references non-existent rule in ${files.tests.filename}`
+                `test '${test.testid}' references non-existent rule in ${files.tests.filename}`
             )
         const res: any = {
-            ...rule,
+            rule,
             ...test,
         }
         return res

--- a/src/genaisrc/src/resolvers.mts
+++ b/src/genaisrc/src/resolvers.mts
@@ -1,5 +1,6 @@
 import type {
     PromptPexContext,
+    PromptPexRule,
     PromptPexTest,
     PromptPexTestGenerationScenario,
 } from "./types.mts"
@@ -109,13 +110,19 @@ export async function resolveRuleHash(files: PromptPexContext, rule: string) {
     return ruleId
 }
 
+/* FIXME: not anymore doing resolve rule */
 export function resolveRule(
-    rules: { rule: string; inverse?: boolean }[],
-    test: PromptPexTest
-) {
-    const index = test.ruleid - 1
-    const rule = rules[index]
-    return { ruleid: index + 1, ...rule }
+    rules: PromptPexRule[]
+): { id: string; rule: string }[] {
+    const output: { id: string; rule: string }[] = []
+
+    for (const r of rules) {
+        output.push({
+            id: r.id,
+            rule: r.inversed ? r.inverseRule : r.rule,
+        })
+    }
+    return output
 }
 
 export async function resolvePromptId(files: PromptPexContext) {

--- a/src/genaisrc/src/rulesgen.mts
+++ b/src/genaisrc/src/rulesgen.mts
@@ -59,6 +59,7 @@ export async function generateOutputRules(
         id: `rule_${i + 1}`,
         rule: r,
         inverseRule: "", // Placeholder for inverse rule, filled in next step
+        inversed: false,
     }))
     files.rules.content = JSON.stringify(pairedRules, null, 2)
     if (files.writeResults) await workspace.writeFiles([files.rules])

--- a/src/genaisrc/src/rulesgen.mts
+++ b/src/genaisrc/src/rulesgen.mts
@@ -4,9 +4,18 @@ import {
     DIAGRAM_GENERATE_OUTPUT_RULES,
 } from "./constants.mts"
 import { outputWorkflowDiagram, outputPrompty } from "./output.mts"
-import { modelOptions, checkLLMResponse, tidyRules } from "./parsers.mts"
+import {
+    modelOptions,
+    checkLLMResponse,
+    tidyRules,
+    parseRules,
+} from "./parsers.mts"
 import { measure } from "./perf.mts"
-import type { PromptPexContext, PromptPexOptions } from "./types.mts"
+import type {
+    PromptPexContext,
+    PromptPexOptions,
+    PromptPexRule,
+} from "./types.mts"
 const dbg = host.logger("promptpex:gen:rules")
 const { generator } = env
 
@@ -44,8 +53,13 @@ export async function generateOutputRules(
             }
         )
     )
-    const rules = tidyRules(checkLLMResponse(res))
-    files.rules.content = rules 
-    if (files.writeResults)
-        await workspace.writeFiles([files.rules])   
+    const rulesText = tidyRules(checkLLMResponse(res))
+    const rulesArray = parseRules(rulesText)
+    const pairedRules: PromptPexRule[] = rulesArray.map((r, i) => ({
+        id: `rule_${i + 1}`,
+        rule: r,
+        inverseRule: "", // Placeholder for inverse rule, filled in next step
+    }))
+    files.rules.content = JSON.stringify(pairedRules, null, 2)
+    if (files.writeResults) await workspace.writeFiles([files.rules])
 }

--- a/src/genaisrc/src/rulesgroundeness.mts
+++ b/src/genaisrc/src/rulesgroundeness.mts
@@ -31,7 +31,6 @@ export async function evaluateRuleGrounded(
     if (file?.content) {
         const res = parsers.JSON5(file) as PromptPexRuleEval
         if (res && !res.error) {
-            res.ruleid = ruleid
             return res
         }
     }
@@ -57,7 +56,6 @@ export async function evaluateRuleGrounded(
     const ruleEval: PromptPexRuleEval = {
         id,
         promptid,
-        ruleid,
         rule,
         groundedText: resText,
         grounded: parseOKERR(resText),

--- a/src/genaisrc/src/testexpand.mts
+++ b/src/genaisrc/src/testexpand.mts
@@ -24,14 +24,12 @@ export async function expandTests(
 
     for (let i = 0; i < ruleTests.length; i++) {
         const test = ruleTests[i]
-        const targetRule = rules[test.ruleid]
         const res = await measure("expand.test", () =>
             generator.runPrompt(
                 (ctx) => {
                     ctx.importTemplate(PROMPT_EXPAND_TEST, {
                         intent: files.intent.content,
                         rules: files.rules.content,
-                        targetRule,
                         test: test.testinput,
                     })
                 },

--- a/src/genaisrc/src/testgen.mts
+++ b/src/genaisrc/src/testgen.mts
@@ -53,7 +53,7 @@ export async function generateTests(
 
     await outputPrompty(pn, options)
 
-    const rulesGroups = splitRules(allRules, options)
+    const mutatedRules = mutateRules(allRules, options)
     const tests: PromptPexTest[] = []
 
     const checkpoint = async () => {
@@ -64,143 +64,163 @@ export async function generateTests(
         await convertToTestData(files, tests)
     }
 
-    dbg(`rule groups: ${rulesGroups.length}`)
+    dbg(`rule groups: ${mutatedRules.length}`)
     for (let si = 0; si < scenarios.length; si++) {
         const scenario = scenarios[si]
         const { instructions, parameters = {} } = scenario
 
         dbg(`scenario: ${scenario.name}`)
-        let rulesCount = 0
-        for (let ri = 0; ri < rulesGroups.length; ri++) {
-            const rulesGroup = rulesGroups[ri]
-            let testGeneration = 0
-            let repaired = false
-            const rule = rulesGroup
-                .map((r, index) => `${rulesCount + index + 1}. ${r.rule}`)
-                .join("\n")
-            dbg(`rule: ${rule}`)
-            const scenarioInstructions = [
-                instructions,
-                ...Object.entries(parameters).map(
-                    ([k, v]) => `'{{${k}}}' = ${v}`
-                ),
-            ]
-                .filter((l) => !!l)
-                .map((l) => `- ${l}`)
-                .join("\n")
+        let testGeneration = 0
+        let repaired = false
+        const rule = mutatedRules
+            .map((r, index) => `${index + 1}. ${r.rule}`)
+            .join("\n")
+        dbg(`rule: ${rule}`)
+        const scenarioInstructions = [
+            instructions,
+            ...Object.entries(parameters).map(([k, v]) => `'{{${k}}}' = ${v}`),
+        ]
+            .filter((l) => !!l)
+            .map((l) => `- ${l}`)
+            .join("\n")
 
-            const args = Object.fromEntries(
-                Object.entries(files.inputs).filter(([k]) => !parameters[k])
+        const args = Object.fromEntries(
+            Object.entries(files.inputs).filter(([k]) => !parameters[k])
+        )
+        dbg(`open args: %O`, args)
+
+        const argNames = Object.keys(args)
+        const testinput_names = argNames.join(", ")
+        const testinput_descriptions = Object.entries(args)
+            .map(
+                ([k, v]) =>
+                    `- "${k}": ${v.type} = ${v.description || `Detailed input '${k}' provided to the software.`}`
             )
-            dbg(`open args: %O`, args)
+            .join("\n")
+        const testinput_example_1 = argNames
+            .map((name) => `input '${name}' for scenario 1`)
+            .join(",")
+        const testinput_example_2 = argNames
+            .map((name) => `input '${name}' for scenario 2`)
+            .join(",")
+        const testinput_count = argNames.length
 
-            const argNames = Object.keys(args)
-            const testinput_names = argNames.join(", ")
-            const testinput_descriptions = Object.entries(args)
-                .map(
-                    ([k, v]) =>
-                        `- "${k}": ${v.type} = ${v.description || `Detailed input '${k}' provided to the software.`}`
-                )
-                .join("\n")
-            const testinput_example_1 = argNames
-                .map((name) => `input '${name}' for rule 1 scenario 1`)
-                .join(",")
-            const testinput_example_2 = argNames
-                .map((name) => `input '${name}' for rule 1 scenario 2`)
-                .join(",")
-            const testinput_count = argNames.length
+        dbg(`testinput: %O`, {
+            testinput_names,
+            testinput_descriptions,
+            testinput_example_1,
+            testinput_example_2,
+            testinput_count,
+        })
 
-            dbg(`testinput: %O`, {
-                testinput_names,
-                testinput_descriptions,
-                testinput_example_1,
-                testinput_example_2,
-                testinput_count,
-            })
-
-            await measure("gen.tests", () =>
-                generator.runPrompt(
-                    (ctx) => {
-                        ctx.importTemplate(pn, {
-                            input_spec: files.inputSpec.content,
-                            context,
-                            num,
-                            scenario: scenarioInstructions,
-                            rule,
-                            num_rules: rulesGroup.length,
-                            testinput_descriptions,
-                            testinput_names,
-                            testinput_example_1,
-                            testinput_example_2,
-                            testinput_count,
-                            test_samples,
-                        })
-                        ctx.defChatParticipant((p, c) => {
-                            const last: string = c.at(-1)?.content as string
-                            dbg(`last message: %s`, last)
-                            if (typeof last !== "string")
-                                throw new Error("Invalid last message")
-                            const csv = parseCsvTests(last, Object.keys(args))
-                            if (!csv.length) {
-                                if (!repaired) {
-                                    dbg(`no tests found, trying to repair`)
-                                    console.warn(
-                                        "Invalid generated test format or no test generated, trying to repair"
-                                    )
-                                    repaired = true
-                                    p.$`The generated tests are not valid CSV. Please fix formatting issues and try again.`
-                                } else {
-                                    output.warn(
-                                        "Invalid generated test format, skipping repair."
-                                    )
-                                    output.fence(last, "txt")
-                                }
+        await measure("gen.tests", () =>
+            generator.runPrompt(
+                (ctx) => {
+                    ctx.importTemplate(pn, {
+                        input_spec: files.inputSpec.content,
+                        context,
+                        num,
+                        scenario: scenarioInstructions,
+                        rule,
+                        num_rules: mutatedRules.length,
+                        testinput_descriptions,
+                        testinput_names,
+                        testinput_example_1,
+                        testinput_example_2,
+                        testinput_count,
+                        test_samples,
+                    })
+                    ctx.defChatParticipant((p, c) => {
+                        const last: string = c.at(-1)?.content as string
+                        dbg(`last message: %s`, last)
+                        if (typeof last !== "string")
+                            throw new Error("Invalid last message")
+                        const csv = parseCsvTests(last, Object.keys(args))
+                        if (!csv.length) {
+                            if (!repaired) {
+                                dbg(`no tests found, trying to repair`)
+                                console.warn(
+                                    "Invalid generated test format or no test generated, trying to repair"
+                                )
+                                repaired = true
+                                p.$`The generated tests are not valid CSV. Please fix formatting issues and try again.`
                             } else {
-                                if (csv?.length) {
-                                    dbg(`adding ${csv.length} tests`)
-                                    tests.push(
-                                        ...csv.map((t) => ({
-                                            ...t,
-                                            scenario: scenario.name,
-                                            generation: testGeneration,
-                                        }))
-                                    )
-                                }
-                                testGeneration++
-                                if (testGeneration < testGenerations) {
-                                    dbg(
-                                        `next test generation ${testGeneration}`
-                                    )
-                                    repaired = false
-                                    p.$`Generate ${num} more tests for the same rules. Do not duplicate the previous tests.`
-                                }
+                                output.warn(
+                                    "Invalid generated test format, skipping repair."
+                                )
+                                output.fence(last, "txt")
                             }
-                        })
-                    },
-                    {
-                        ...modelOptions(rulesModel, options),
-                        label: `${files.name}> generate tests (${SCENARIO_SYMBOL} ${scenario.name} ${si + 1}/${scenarios.length}, ${RULE_SYMBOL} ${ri + 1}/${rulesGroups.length}, ${GENERATION_SYMBOL} ${testGeneration + 1}/${testGenerations})`,
-                    }
-                )
+                        } else {
+                            if (csv?.length) {
+                                dbg(`adding ${csv.length} tests`)
+                                tests.push(
+                                    ...csv.map((t) => ({
+                                        ...t,
+                                        scenario: scenario.name,
+                                        generation: testGeneration,
+                                    }))
+                                )
+                            }
+                            testGeneration++
+                            if (testGeneration < testGenerations) {
+                                dbg(`next test generation ${testGeneration}`)
+                                repaired = false
+                                p.$`Generate ${num} more tests for the same rules. Do not duplicate the previous tests.`
+                            }
+                        }
+                    })
+                },
+                {
+                    ...modelOptions(rulesModel, options),
+                    label: `${files.name}> generate tests (${SCENARIO_SYMBOL} ${scenario.name} ${si + 1}/${scenarios.length}, ${RULE_SYMBOL} ${GENERATION_SYMBOL} ${testGeneration + 1}/${testGenerations})`,
+                }
             )
-            await checkpoint()
-            // TODO retry
-            rulesCount += rulesGroup.length
-        }
+        )
+        await checkpoint()
+        // TODO retry
     }
 
     await checkpoint()
     return tests
 }
 
-function splitRules(rules: PromptPexRule[], options?: PromptPexOptions) {
-    const { splitRules, maxRulesPerTestGeneration } = options || {}
-    let res = splitRules
-        ? [rules.filter((r) => !r.inverse), rules.filter((r) => r.inverse)]
-        : [rules.slice(0)]
-    if (maxRulesPerTestGeneration > 0)
-        res = res.flatMap((r) => chunkArray(r, maxRulesPerTestGeneration))
-    return res
+function mutateRules(
+    rules: PromptPexRule[],
+    options?: PromptPexOptions
+): { id: string; rule: string }[] {
+    const { mutateRule } = options || {}
+    const output: { id: string; rule: string }[] = []
+    /* Find the index of the currently inversed rule, if any */
+    const currentInversedIdx = rules.findIndex((r) => r.inversed)
+
+    if (mutateRule) {
+        /* Determine the next rule to inverse:
+         * If none are currently inversed, start with the first rule (index 0),
+         * otherwise move to the next rule in the list.
+         */
+        const nextIndex = currentInversedIdx === -1 ? 0 : currentInversedIdx + 1
+
+        /* Reset all rules to not inversed */
+        rules.forEach((r) => (r.inversed = false))
+
+        /* Set the next rule as inversed if within bounds */
+        if (nextIndex < rules.length) {
+            rules[nextIndex].inversed = true
+        }
+    }
+
+    /* Generate output list:
+     * Include the inverseRule only for the currently inversed rule,
+     * all others should return the original rule.
+     */
+    for (const r of rules) {
+        output.push({
+            id: r.id,
+            rule: r.inversed ? r.inverseRule : r.rule,
+        })
+    }
+
+    return output
 }
 
 function chunkArray<T>(array: T[], n: number): T[][] {

--- a/src/genaisrc/src/testgen.mts
+++ b/src/genaisrc/src/testgen.mts
@@ -53,7 +53,7 @@ export async function generateTests(
 
     await outputPrompty(pn, options)
 
-    const mutatedRules = mutateRules(allRules, options)
+    const mutatedRules = mutateRules(allRules, files, options)
     const tests: PromptPexTest[] = []
 
     const checkpoint = async () => {
@@ -186,6 +186,7 @@ export async function generateTests(
 
 function mutateRules(
     rules: PromptPexRule[],
+    files: PromptPexContext,
     options?: PromptPexOptions
 ): { id: string; rule: string }[] {
     const { mutateRule } = options || {}
@@ -207,6 +208,8 @@ function mutateRules(
         if (nextIndex < rules.length) {
             rules[nextIndex].inversed = true
         }
+
+        if (files.writeResults) workspace.writeFiles([files.rules])
     }
 
     /* Generate output list:

--- a/src/genaisrc/src/testquality.mts
+++ b/src/genaisrc/src/testquality.mts
@@ -70,7 +70,9 @@ export async function evaluateTestQuality(
     const allRules = parseAllRules(files)
     if (!allRules) throw new Error("No rules found")
 
-    const rule = resolveRule(allRules, test)
+    const rule = resolveRule(allRules)
+        .map((r, index) => `${index + 1}. ${r.rule}`)
+        .join("\n")
     if (!rule && !test.baseline)
         throw new Error(`No rule found for test ${test["ruleid"]}`)
 
@@ -79,7 +81,7 @@ export async function evaluateTestQuality(
         return {
             id,
             promptid,
-            ...rule,
+            rule,
             input: testInput,
             error: "invalid test input",
         } satisfies PromptPexTestEval
@@ -131,7 +133,7 @@ export async function evaluateTestQuality(
         id,
         promptid,
         model: resCoverage.model,
-        ...rule,
+        rule,
         input: testInput,
         validityText: resValidity.text,
         validity: validity,
@@ -145,7 +147,6 @@ export async function evaluateTestQuality(
             id: "cov-" + testEval.id,
             scenario: test.scenario,
             rule: testEval.rule,
-            ruleid: test.ruleid,
             testinput: test.testinput,
             promptid,
             model: testEval.model,

--- a/src/genaisrc/src/testquality.mts
+++ b/src/genaisrc/src/testquality.mts
@@ -94,7 +94,7 @@ export async function evaluateTestQuality(
                         ctx.importTemplate(PROMPT_EVAL_OUTPUT_RULE_AGREEMENT, {
                             intent,
                             rules: allRules
-                                .filter((r) => !r.inverse)
+                                .filter((r) => !r.inversed)
                                 .map((r) => r.rule)
                                 .join("\n"),
                             testInput,
@@ -151,7 +151,7 @@ export async function evaluateTestQuality(
             model: testEval.model,
             input: testEval.input,
             output: testEval.coverageText,
-            metrics: {}
+            metrics: {},
         },
         options
     )

--- a/src/genaisrc/src/testrun.mts
+++ b/src/genaisrc/src/testrun.mts
@@ -111,13 +111,15 @@ async function runTest(
     })
     const { inputs, args, testInput } = resolvePromptArgs(files, test)
     const allRules = parseAllRules(files, options)
-    const rule = resolveRule(allRules, test)
+    const rule = resolveRule(allRules)
+        .map((r, index) => `${index + 1}. ${r.rule}`)
+        .join("\n")
     if (!args) {
         dbg(`invalid test input %O`, { test, inputs, testInput })
         return {
             id,
             promptid,
-            ...rule,
+            rule,
             scenario: test.scenario,
             baseline: test.baseline,
             testinput: testInput,
@@ -162,7 +164,7 @@ async function runTest(
     const testRes: PromptPexTestResult = {
         id,
         promptid,
-        ...rule,
+        rule,
         scenario: test.scenario,
         baseline: test.baseline,
         testinput: testInput,

--- a/src/genaisrc/src/types.mts
+++ b/src/genaisrc/src/types.mts
@@ -244,10 +244,6 @@ export interface PromptPexContext {
 
 export interface PromptPexTest {
     /**
-     * Index of the rule in the OR+IOR rules. undefined for baseline tests.
-     */
-    ruleid?: number
-    /**
      * Index of the generated test for the given rule. undefined for baseline tests
      */
     testid?: number
@@ -286,7 +282,6 @@ export interface PromptPexTest {
 export interface PromptPexTestResult {
     id: string
     promptid: string
-    ruleid: number
     rule: string
     scenario: string
     testinput: string
@@ -332,7 +327,6 @@ export type PromptPexEvalResultType = "ok" | "err" | "unknown"
 export interface PromptPexRuleEval {
     id: string
     promptid: string
-    ruleid: number
     rule: string
     groundedText?: string
     grounded?: PromptPexEvalResultType

--- a/src/genaisrc/src/types.mts
+++ b/src/genaisrc/src/types.mts
@@ -130,6 +130,12 @@ export interface PromptPexOptions extends PromptPexLoaderOptions {
      * Creates a new eval run in OpenAI. Requires OpenAI API key.
      */
     createEvalRuns?: boolean
+
+    /**
+     * Mutate one OR into IR if mutateRule is true.
+     * If false, the inverse rules will be generated as is.
+     */
+    mutateRule?: boolean
 }
 
 /**
@@ -318,7 +324,7 @@ export interface PromptPexRule {
     id: string
     rule: string
     inverseRule: string
-    inverse?: boolean
+    inversed?: boolean
 }
 
 export type PromptPexEvalResultType = "ok" | "err" | "unknown"

--- a/src/genaisrc/src/types.mts
+++ b/src/genaisrc/src/types.mts
@@ -315,7 +315,9 @@ export interface PromptPexTestEval {
 }
 
 export interface PromptPexRule {
+    id: string
     rule: string
+    inverseRule: string
     inverse?: boolean
 }
 

--- a/src/prompts/expand_test.prompty
+++ b/src/prompts/expand_test.prompty
@@ -7,14 +7,11 @@ inputs:
         type: string
     rules:
         type: string
-    targetRule:
-        type: string
     test:
         type: string
 sample:
     intent: "Determine the part of speech for a given word"
     rules: "The output must contain only a single string that represents the part-of-speech tag"  
-    targetRule: "The output must contain only a single string"
     test: "sentence: The cat is on the mat., word: cat"
 ---
 system:
@@ -22,12 +19,12 @@ Your task is to expand a test case into a more realistic and comprehensive versi
 
 1. The <INTENT/> of the prompt under test
 2. The <OUTPUT_RULES/> that govern valid responses
-3. The specific <TARGET_RULE/> this test case was designed to verify
-4. The original <TEST_CASE/>
+3. The original <TEST_CASE/>
 
 ## Guidelines for expansion:
 
-1. **Preserve Rule Coverage**: The expanded test must still test the same target rule. The fundamental aspects that made the original test case valid must be maintained.
+1. **Preserve Rule Coverage**: The expanded test must still test the original intent and verify **the rule set as a whole**. If the original test was meant to validate rule-compliant behavior, the expanded test should do the same.
+
 
 2. **Add Realistic Context**: Make the test case more realistic by:
    - Adding more context and detail
@@ -67,10 +64,6 @@ user:
 <OUTPUT_RULES>
 {{rules}}
 </OUTPUT_RULES>
-
-<TARGET_RULE>
-{{targetRule}}
-</TARGET_RULE>
 
 <TEST_CASE>
 {{test}}

--- a/src/prompts/generate_tests.prompty
+++ b/src/prompts/generate_tests.prompty
@@ -46,7 +46,9 @@ inputs:
         default: "input based on rule 1 scenario 2"
 ---
 system:
-You are tasked with developing multiple test cases for an software, given its functional and input specification and a list of rules in <RULES> as input. For each rule, you must create {{num}} test cases. These test cases must be designed to validate whether the software's outputs correctly adhere to a particular rule. These tests must be well defined based on the input specifications.
+You are tasked with developing multiple test cases for an software, given its functional and input specification and a list of rules in <RULES> as input. 
+Instead of creating test cases for each rule independently, use the full list of rules in <RULES> as a **single policy** that the software must follow.
+You are to generate {{num}} test inputs that **jointly test** whether the software correctly adheres to **all rules**.
 
 Start with first understanding what is a input for the software using the given input specification. Understand what are the different components of a valid input, what are the syntax and semantics related constraints. A good test must always be a valid input meeting the requirements from the given input specification.
 
@@ -79,7 +81,7 @@ Also focus on clues like length and style of these tests.
 Guidelines for generating test cases:
 - Analyze the input specifications to understand the valid input formats, components of the input and scenarios for the software.
 - If the test case have multiple components, try to use all the components in the test case and tag them with their name, like, component name: value
-- Develop {{num}} test cases for each rule provided in the list.
+- Develop {{num}} test cases for the whole rule provided in the list.
 - Each test case must be crafted to rigorously assess whether the software's output meets the stipulated rule based on the inputs that conform to the provided input specification.
 - Use valid and realistic input scenarios that fully comply with the input specifications and are relevant to the rule being tested.
 - Specify clearly in each test case the input given to the software and the expected output or behavior that demonstrates adherence to the rule.
@@ -89,7 +91,6 @@ Guidelines for generating test cases:
 Each test case should adhere to principles of good software testing practices, emphasizing coverage, specificity and independence. Critically assess potential weaknesses in the software's handling of inputs based on the rule and focus on creating diverse test cases that effectively challenge the software's capabilities.
 
 Format your response in a structured CSV format as follows:
-- "ruleid": number = Identifier for the rule being tested.
 - "testid": number = Sequential identifier for each test case under a rule.
 - "expectedoutput": string =  Output or behavior expected from the software to affirm rule adherence.
 - "reasoning": string = Brief explanation of why this test case is relevant and contributes to robust testing of the rule. List the input specification that this test case does not follow. Keep a minimum draft, with 20 words at most.
@@ -97,14 +98,13 @@ Format your response in a structured CSV format as follows:
 
 
 Example CSV layout:
-ruleid, testid, expectedoutput, reasoning, {{testinput_names}}
-1, 1, "expected outcome demonstrating rule adherence", "Explains the relevance and effectiveness of the test and how it follows the input specification", {{testinput_example_1}}
-1, 2, "expected response confirming rule", "Illustrates how inputs challenge the software and ensure compliance and how is a valid test case based on input specification", {{testinput_example_2}}
+testid, expectedoutput, reasoning, {{testinput_names}}
+1, "expected outcome demonstrating rule adherence", "Explains the relevance and effectiveness of the test and how it follows the input specification", {{testinput_example_1}}
+2, "expected response confirming rule", "Illustrates how inputs challenge the software and ensure compliance and how is a valid test case based on input specification", {{testinput_example_2}}
 
 Only output the test cases in the specified CSV format and nothing else. Please make sure that the CSV generated is well formed, only have {{4 + testinput_count}} columns and each value in a these columns must only have commas inside quoted value else they will be counted as a new column. Do not wrap the output in any additional text or formatting like triple backticks or quotes.
 
-Since you will be given {{num_rules}} rules in <RULES>, you are expected to generated {{num_rules * num}} tests, {{num}} for each given rule.
-
+You are expected to generated {{num}} tests.
 user:
 <RULES>
 {{rule}}


### PR DESCRIPTION
### (1) OR과 IR을 대응해서 저장합니다.
- 다음과 같이 rules에 OR과 IR을 짝지어서 함께 저장합니다.
```
[
  {
    "id": "rule_1",
    "rule": "If the output contains the entity \"UN chief\", \"climate change\", and \"catastrophe\", then classify the news article as \"World\".",
    "inverseRule": "If the output does not contain \"UN chief\", \"climate change\", or \"catastrophe\", then classify the news article as not \"World\"."
  },
  {
    "id": "rule_2",
    "rule": "If the output contains the entity \"Ronaldo\", \"Manchester United\", and \"returns\", then classify the news article as \"Sports\".",
    "inverseRule": "If the output does not contain \"Ronaldo\", \"Manchester United\", or \"returns\", then classify the news article as not \"Sports\"."
  }
]
```
- TODO: 아직 IR 생성 시, OR을 한 번에 넘겨주고 "이에 대응하는 IRs를 생성해줘" 하는 식이기 때문에 OR-IR 대응이 정확하지 않은 경우가 있습니다. 이 부분을 1:1 대응이 되도록 수정해야 합니다.

### (2) OR set을 기준으로 test input을 생성합니다.
- BEFORE:
  - OR rule 한 개당 이에 대응하는 test input을 생성합니다.
- AFTER:
  - multiple OR (OR의 set)에 대응하는 test input을 생성합니다. 
  - `generate_test.prompty` 수정으로 구현했습니다.

### (3) OR set의 규칙들을 차례대로 mutate합니다.
- 다음과 같이 차례대로 개별 OR이 대응하는 IR로 mutate되도록 합니다.
```
1. OR1*, OR2, OR3, … ORn
2. OR1, OR2*, OR3, … , ORn
...
```