### PR TITLE
Fix/display rules

### DIFF
--- a/src/genaisrc/promptpex.genai.mts
+++ b/src/genaisrc/promptpex.genai.mts
@@ -441,12 +441,12 @@ if (!anyStepRequested) {
         } else {
             output.heading(3, "Output Rules")
             await generateOutputRules(files, options)
-            outputLines(files.rules, "rule")
+            outputLines(files.rules, "rule", "rule")
             await checkConfirm("rule")
 
             output.heading(3, "Inverse Output Rules")
             await generateInverseOutputRules(files, options)
-            outputLines(files.inverseRules, "generate inverse output rule")
+            outputLines(files.rules, "generate inverse output rule", "inverseRule")
             await checkConfirm("inverse")
         }
     }

--- a/src/genaisrc/src/output.mts
+++ b/src/genaisrc/src/output.mts
@@ -41,11 +41,24 @@ export function outputFile(file: WorkspaceFile) {
     output.fence(file.content, contentType)
 }
 
-export function outputLines(file: WorkspaceFile, name: string) {
+export function outputLines(file: WorkspaceFile, name: string, mode: 'rule' | 'inverseRule' = 'rule') {
     const { output } = env
     const { content, filename } = file
     const contentType = path.extname(filename)
-    const lines = content?.split("\n").map((line) => ({ [name]: line })) || []
+  
+    let lines: Record<string, string>[] = []
+  
+    try {
+      const parsed = JSON.parse(content)
+      if (Array.isArray(parsed)) {
+        lines = parsed.map((entry) => ({ [name]: entry[mode] }))
+      } else {
+        throw new Error("Parsed content is not an array.")
+      }
+    } catch (e) {
+      lines = content?.split("\n").map((line) => ({ [name]: line })) || []
+    }
+  
     output.table(lines)
     output.detailsFenced(`data`, content, contentType)
-}
+  }

--- a/src/genaisrc/src/parsers.mts
+++ b/src/genaisrc/src/parsers.mts
@@ -89,6 +89,24 @@ export function tidyRules(text: string) {
         .join("\n")
 }
 
+export function tidyRulePairs(
+    text: string,
+    mode: "rule" | "inverseRule" = "rule"
+) {
+    if (isUnassistedResponse(text)) return ""
+    try {
+        const parsed = JSON.parse(text)
+        if (Array.isArray(parsed)) {
+            return parsed
+                .map((entry) => entry[mode])
+                .filter((line) => typeof line === "string")
+                .join("\n")
+        }
+    } catch {
+        dbg(`Failed to parse JSON: ${text}`)
+    }
+}
+
 export function tidyRulesFile(file: WorkspaceFile) {
     if (file?.content) file.content = tidyRules(file.content)
     return file
@@ -98,6 +116,20 @@ export function parseRules(rules: string, options?: PromptPexOptions) {
     const { maxRules } = options || {}
     const res = rules
         ? tidyRules(rules)
+              .split(/\r?\n/g)
+              .map((l) => l.trim())
+              .filter((l) => !!l)
+        : []
+    return maxRules > 0 ? res.slice(0, maxRules) : res
+}
+
+export function parseRulePairs(
+    rules: string,
+    options?: PromptPexOptions & { mode?: "rule" | "inverseRule" }
+) {
+    const { maxRules, mode = "rule" } = options || {}
+    const res = rules
+        ? tidyRulePairs(rules, mode)
               .split(/\r?\n/g)
               .map((l) => l.trim())
               .filter((l) => !!l)

--- a/src/genaisrc/src/reports.mts
+++ b/src/genaisrc/src/reports.mts
@@ -3,7 +3,7 @@ import {
     parseAllRules,
     parseBaselineTests,
     parseRuleEvals,
-    parseRules,
+    parseRulePairs,
     parseRulesTests,
     parseTestEvals,
     parseTestResults,
@@ -153,10 +153,12 @@ async function generateMarkdownReport(files: PromptPexContext) {
         ...parseRulesTests(files.tests.content),
         ...parseBaselineTests(files),
     ]
-    const rules = parseRules(files.rules.content)
+    const rules = parseRulePairs(files.rules.content)
     const ruleEvals = parseRuleEvals(files)
     const groundedRuleEvals = ruleEvals.filter((r) => r.grounded === "ok")
-    const inverseRules = parseRules(files.inverseRules.content)
+    const inverseRules = parseRulePairs(files.rules.content, {
+        mode: "inverseRule",
+    })
     const testResults = parseTestResults(files)
     const ts = testResults.length
     const oks = testResults.filter((t) => t.compliance === "ok").length
@@ -303,8 +305,10 @@ export async function generateJSONReport(files: PromptPexContext) {
     const prompt = files.prompt.content
     const inputSpec = files.inputSpec.content
     const errors: string[] = []
-    const rules = parseRules(files.rules.content)
-    const inverseRules = parseRules(files.inverseRules.content)
+    const rules = parseRulePairs(files.rules.content)
+    const inverseRules = parseRulePairs(files.rules.content, {
+        mode: "inverseRule",
+    })
     const allRules = parseAllRules(files)
     const rulesTests = parseRulesTests(files.tests.content)
     const baseLineTests = parseBaselineTests(files)

--- a/src/genaisrc/src/rulesgroundeness.mts
+++ b/src/genaisrc/src/rulesgroundeness.mts
@@ -4,7 +4,7 @@ import {
     modelOptions,
     checkLLMResponse,
     parseOKERR,
-    parseRules,
+    parseRulePairs,
 } from "./parsers.mts"
 import { resolveRuleEvalPath } from "./filecache.mts"
 import type {
@@ -73,7 +73,7 @@ export async function evaluateRulesGrounded(
     files: PromptPexContext,
     options?: PromptPexOptions
 ) {
-    const rules = parseRules(files.rules.content)
+    const rules = parseRulePairs(files.rules.content)
     if (!rules) {
         dbg(
             `failed to parse rules in ${files.rules.filename} %O`,

--- a/src/genaisrc/src/testexpand.mts
+++ b/src/genaisrc/src/testexpand.mts
@@ -2,7 +2,7 @@ import { PROMPT_EXPAND_TEST } from "./constants.mts"
 import {
     checkLLMResponse,
     modelOptions,
-    parseRules,
+    parseRulePairs,
     parseRulesTests,
 } from "./parsers.mts"
 import { measure } from "./perf.mts"
@@ -20,7 +20,7 @@ export async function expandTests(
     options?: PromptPexOptions
 ) {
     const ruleTests = parseRulesTests(files.tests.content)
-    const rules = parseRules(files.rules.content)
+    const rules = parseRulePairs(files.rules.content)
 
     for (let i = 0; i < ruleTests.length; i++) {
         const test = ruleTests[i]

--- a/src/genaisrc/test.genai.mts
+++ b/src/genaisrc/test.genai.mts
@@ -4,7 +4,7 @@ import { generateInverseOutputRules } from "./src/inverserulesgen.mts"
 import { loadPromptFiles } from "./src/loaders.mts"
 import {
     parseBaselineTests,
-    parseRules,
+    parseRulePairs,
     parseRulesTests,
     parseTestResults,
 } from "./src/parsers.mts"
@@ -53,13 +53,15 @@ output.fence(files.inputSpec.content, "text")
 output.heading(3, "Output Rules")
 await generateOutputRules(files, options)
 output.fence(files.rules.content, "text")
-const rules = parseRules(files.rules.content)
+const rules = parseRulePairs(files.rules.content)
 if (!rules?.length) throw new Error("No rules found")
 
 output.heading(3, "Inverse Output Rules")
 await generateInverseOutputRules(files, options)
 output.fence(files.inverseRules.content, "text")
-const inverseRules = parseRules(files.inverseRules.content)
+const inverseRules = parseRulePairs(files.rules.content, {
+    mode: "inverseRule",
+})
 if (!inverseRules?.length) throw new Error("No inverse rules found")
 
 output.heading(3, "Tests")


### PR DESCRIPTION
### GUI 상에서 OR, IR이 제대로 출력될 수 있도록 수정합니다.
- [files.inverseRule을 더이상 생성하지 않는데](https://github.com/farawell/CS453_team3/pull/2#discussion_r2123710918), GUI에 결과를 띄울 때는 해당 파일을 여전히 참조하고 있어서 문제가 발생했습니다.
- files.rules를 parsing 하여 OR과 IR 각각을 띄울 수 있도록 변경하였습니다.
- fixed GUI:
  ![image](https://github.com/user-attachments/assets/739b9ada-b92b-41b7-8dc7-f8f6275b23ce)
- [minor] 이 외에도, files.inverseRule를 여전히 참조하고 있던 코드를 수정했습니다.